### PR TITLE
Update to the latest (which has better perf)

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,7 +1,7 @@
 # build the image and tag it appropriately
 
-docker buildx build --platform linux/amd64,linux/arm64 --build-arg SOLANA_CLI=1.17.29 -f Dockerfile -t ghcr.io/wormholelabs-xyz/solana-test-validator:1.17.29 .
+docker buildx build --platform linux/amd64,linux/arm64 --build-arg SOLANA_SHA=beacdfc51cd395091b849a59d74112f302b3fb32 -f Dockerfile -t ghcr.io/wormholelabs-xyz/solana-test-validator:3.0.0 .
 
 # push to ghcr
 
-docker push ghcr.io/wormholelabs-xyz/solana-test-validator:1.17.29
+docker push ghcr.io/wormholelabs-xyz/solana-test-validator:3.0.0

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,7 +1,7 @@
 # build the image and tag it appropriately
 
-docker buildx build --platform linux/amd64,linux/arm64 --build-arg SOLANA_SHA=beacdfc51cd395091b849a59d74112f302b3fb32 -f Dockerfile -t ghcr.io/wormholelabs-xyz/solana-test-validator:3.0.0 .
+docker buildx build --platform linux/amd64,linux/arm64 --build-arg SOLANA_SHA=5a06890206cf9f00a5fbd253b8f417cc5c3a075c -f Dockerfile -t ghcr.io/wormholelabs-xyz/solana-test-validator:3.0.12 .
 
 # push to ghcr
 
-docker push ghcr.io/wormholelabs-xyz/solana-test-validator:3.0.0
+docker push ghcr.io/wormholelabs-xyz/solana-test-validator:3.0.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,19 @@ FROM ubuntu:20.04@sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y curl wget libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler
+RUN apt-get update && \
+    apt-get install -y curl git libssl-dev libudev-dev pkg-config zlib1g-dev llvm clang cmake make libprotobuf-dev protobuf-compiler libclang-dev && \
+    rm -rf /var/cache/apt/archives /var/lib/apt/lists/*.
 
 WORKDIR /build
 
-ARG SOLANA_CLI
+ARG SOLANA_SHA
 
-RUN wget "https://github.com/anza-xyz/agave/archive/refs/tags/v${SOLANA_CLI}.tar.gz"
+RUN git init && \
+    git remote add origin "https://github.com/anza-xyz/agave.git" && \
+    git fetch --depth=1 origin ${SOLANA_SHA} && \
+    git reset --hard FETCH_HEAD
 
-RUN tar -xf v${SOLANA_CLI}.tar.gz
-
-WORKDIR /build/agave-${SOLANA_CLI}
 
 RUN bash -c ". ci/rust-version.sh && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain \$rust_stable && \
@@ -23,7 +25,8 @@ ENV PATH=/root/.cargo/bin:$PATH
 
 RUN ./cargo build --profile release --bin solana-test-validator
 
-RUN mkdir bin && cp target/release/solana-test-validator /bin/solana-test-validator
+RUN mkdir bin && \
+    mv target/release/solana-test-validator /bin/solana-test-validator
 
 FROM ubuntu:20.04@sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b AS export
 


### PR DESCRIPTION
Switched to git sha instead of version number.

Since [my memory PR](https://github.com/anza-xyz/agave/pull/7269) was merged, we can now use a recent stable and use flags to enable low memory usage mode.